### PR TITLE
Features/20200401 shorter urls

### DIFF
--- a/app/javascript/components/restaurant.jsx
+++ b/app/javascript/components/restaurant.jsx
@@ -4,6 +4,14 @@ import Location from './location';
 class Restaurant extends React.Component {
   render() {
     const { restaurant } = this.props;
+    var websiteStr
+    websiteStr = restaurant.website
+    websiteStr = websiteStr.replace(/\/$/, '')
+    websiteStr = websiteStr.split('://')
+    websiteStr = websiteStr[1].split('www.')
+    if (websiteStr[1]) {
+      websiteStr = websiteStr[1]
+    }
     return (
       <div className='component-restaurant card'>
         <div className='header'>
@@ -12,7 +20,7 @@ class Restaurant extends React.Component {
             {
               restaurant.website &&
               <a href={`${restaurant.website}`} target="_blank">
-                {restaurant.website}
+                  {websiteStr}
               </a>
             }
             {

--- a/app/javascript/components/restaurant.jsx
+++ b/app/javascript/components/restaurant.jsx
@@ -8,9 +8,11 @@ class Restaurant extends React.Component {
     websiteStr = restaurant.website
     websiteStr = websiteStr.replace(/\/$/, '')
     websiteStr = websiteStr.split('://')
-    websiteStr = websiteStr[1].split('www.')
     if (websiteStr[1]) {
-      websiteStr = websiteStr[1]
+      websiteStr = websiteStr[1].split('www.')
+      if (websiteStr[1]) {
+        websiteStr = websiteStr[1]
+      }
     }
     return (
       <div className='component-restaurant card'>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_22_235224) do
+ActiveRecord::Schema.define(version: 2020_04_02_014727) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -29,6 +29,12 @@ ActiveRecord::Schema.define(version: 2020_03_22_235224) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "phone"
     t.string "website"
+    t.string "pickup_url"
+    t.string "delivery_url"
+    t.string "skip_the_dishes_url"
+    t.string "uber_eats_url"
+    t.string "foodora_url"
+    t.string "door_dash_url"
     t.index ["restaurant_id"], name: "index_locations_on_restaurant_id"
   end
 


### PR DESCRIPTION
Shorten the displayed restaurant website URL.
* Strip out any trailing slashes
* Strip out initial `http://` or `https://`
* Strip out `www.`

@caseyli let me know if you see any issues with this approach.
